### PR TITLE
Improve paraphrase pipeline and extensibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Para evitar avisos sobre o uso de modelos da Hugging Face, crie um token de aute
 - A biblioteca `nltk` foi usada para tokenizar as frases.
 
 ### 2. Geração de Exemplos de Plágio Semântico (Paráfrases)
-- Utilizamos o modelo Pegasus, através do pipeline de `summarization`, para gerar paráfrases das frases do texto original.
-- O parâmetro `max_length` foi ajustado e as frases longas foram truncadas para evitar problemas durante a geração das paráfrases.
+- Utilizamos um modelo Pegasus mais robusto (`google/pegasus-large` por padrão) via pipeline de `text2text-generation`, permitindo alternar para checkpoints fine-tunados definindo a variável de ambiente `PARAPHRASE_MODEL_NAME`.
+- O valor de `max_length` agora é configurável (padrão: 128) e o parâmetro `truncation` foi mantido para evitar que frases muito longas percam contexto sem ultrapassar o limite do modelo. Ajuste via `PARAPHRASE_MAX_LENGTH` conforme necessário.
 
 ### 3. Detecção de Similaridade Léxica
 - Foi utilizada a técnica de TF-IDF (`Term Frequency-Inverse Document Frequency`) para representar os textos como vetores numéricos.
@@ -79,9 +79,9 @@ Para evitar avisos sobre o uso de modelos da Hugging Face, crie um token de aute
 - **Recomendações:** Sugere-se ajustar o treinamento do modelo Pegasus para melhorar a qualidade das paráfrases e minimizar warnings. Além disso, ajustar `max_length` pode evitar perda de conteúdo relevante nas paráfrases.
 
 ### Recomendações Finais
-1. **Melhoria do Modelo de Paráfrase:** A qualidade das paráfrases pode ser melhorada através do treinamento adicional do modelo Pegasus ou a substituição por um modelo pré-treinado mais robusto.
-2. **Aprimoramento de Hiperparâmetros:** Ajustar o valor de `max_length` e `truncation` para garantir que as frases mantenham seu contexto e significado.
-3. **Integração de APIs Externas:** Futuramente, integrar uma API de plágio popular, como o Turnitin, poderia melhorar a precisão e permitir comparações com uma base de dados maior.
+1. **Melhoria do Modelo de Paráfrase:** A qualidade das paráfrases pode ser melhorada através do treinamento adicional do modelo Pegasus ou da substituição por um modelo pré-treinado mais robusto, agora suportada via configuração do pipeline e variáveis de ambiente.
+2. **Aprimoramento de Hiperparâmetros:** Ajustar o valor de `max_length` e `truncation` para garantir que as frases mantenham seu contexto e significado; os novos parâmetros padrão já refletem essa recomendação.
+3. **Integração de APIs Externas:** Uma interface para acoplar APIs de plágio (ex.: Turnitin) está disponível para extensão futura, possibilitando comparações com bases maiores quando a integração for implementada.
 
 ## Como Contribuir
 Este projeto é de código aberto e colaborativo. Caso deseje contribuir:

--- a/src/plagio_detection.py
+++ b/src/plagio_detection.py
@@ -1,11 +1,15 @@
 # -*- coding: utf-8 -*-
 """Módulo para geração e detecção de plágio léxico e semântico."""
+import os
 import random
+from dataclasses import dataclass
+from typing import List, Optional
+
 import nltk
+import numpy as np
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 from transformers import pipeline
-import numpy as np
 
 nltk.download('punkt', quiet=True)
 
@@ -20,19 +24,64 @@ def gerar_plagio_lexico(texto: str, n: int = 3):
     return exemplos
 
 
+@dataclass
+class ParaphraseConfig:
+    """Configurações para geração de paráfrases."""
+
+    model_name: str = os.getenv(
+        "PARAPHRASE_MODEL_NAME", "google/pegasus-large"
+    )  # modelo mais robusto por padrão
+    max_length: int = int(os.getenv("PARAPHRASE_MAX_LENGTH", 128))
+    truncation: bool = True
+
+
+def criar_pipeline_parafrase(config: Optional[ParaphraseConfig] = None):
+    """Cria o pipeline de paráfrase com base na configuração fornecida."""
+
+    config = config or ParaphraseConfig()
+    return pipeline(
+        "text2text-generation",
+        model=config.model_name,
+        tokenizer=config.model_name,
+    )
+
+
 # Paraphrase pipeline usado na geração de plágio semântico
-paraphrase_pipeline = pipeline("summarization", model="tuner007/pegasus_paraphrase")
+paraphrase_config = ParaphraseConfig()
+paraphrase_pipeline = criar_pipeline_parafrase(paraphrase_config)
 
 
-def gerar_plagio_semantico(texto: str, n: int = 3):
-    """Gera exemplos de plágio semântico via paraphrase."""
+def gerar_plagio_semantico(
+    texto: str,
+    n: int = 3,
+    config: Optional[ParaphraseConfig] = None,
+    pipeline_parafrase=None,
+) -> List[str]:
+    """Gera exemplos de plágio semântico via paráfrase.
+
+    Args:
+        texto: Texto de entrada.
+        n: Número de paráfrases a gerar por frase.
+        config: Configuração do pipeline de paráfrase.
+        pipeline_parafrase: Pipeline customizado (ex.: modelo Pegasus fine-tuned).
+    """
+
+    config = config or paraphrase_config
+    pipeline_parafrase = pipeline_parafrase or paraphrase_pipeline
+
     frases = nltk.sent_tokenize(texto, language="portuguese")
-    exemplos = []
+    exemplos: List[str] = []
     for frase in frases:
-        if len(frase.split()) > 50:
-            frase = " ".join(frase.split()[:50])
-        paraphrases = paraphrase_pipeline(frase, num_return_sequences=n, max_length=60, truncation=True)
-        exemplos.extend([p["summary_text"] for p in paraphrases])
+        palavras = frase.split()
+        if len(palavras) > config.max_length:
+            frase = " ".join(palavras[: config.max_length])
+        paraphrases = pipeline_parafrase(
+            frase,
+            num_return_sequences=n,
+            max_length=config.max_length,
+            truncation=config.truncation,
+        )
+        exemplos.extend([p["generated_text"] for p in paraphrases])
     return exemplos
 
 
@@ -52,6 +101,32 @@ def calcular_similaridade_semantica(texto1: str, texto2: str) -> float:
     embedding2 = np.mean(similarity_pipeline(texto2)[0], axis=0)
     similarity = cosine_similarity([embedding1], [embedding2])
     return similarity[0][0]
+
+
+class ExternalPlagiarismAPI:
+    """Interface para integrar provedores externos (ex.: Turnitin).
+
+    Esta classe serve como ponto de extensão para futuras integrações e não
+    realiza chamadas externas neste momento.
+    """
+
+    def __init__(self, api_key: Optional[str] = None):
+        self.api_key = api_key or os.getenv("TURNITIN_API_KEY")
+
+    def verificar_plagio(self, texto: str, submission_id: Optional[str] = None):
+        """Envia um texto para comparação em uma API externa.
+
+        Args:
+            texto: Conteúdo a ser comparado.
+            submission_id: Identificador opcional para rastreamento.
+
+        Raises:
+            NotImplementedError: Implementação pendente para integração real.
+        """
+
+        raise NotImplementedError(
+            "Integração com API externa pendente (ex.: Turnitin)."
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a configurable Pegasus paraphrasing pipeline with more robust defaults and tunable hyperparameters
- allow semantic plagiarism generation to accept custom/fine-tuned pipelines and clarified truncation handling
- document the configuration options and expose a stub for future external plagiarism API integration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923bf3f15b883259a3c77a0ed570a21)